### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/recipes-applications/gqrx/gqrx_git.bb
+++ b/recipes-applications/gqrx/gqrx_git.bb
@@ -9,7 +9,7 @@ inherit cmake_qt5
 
 PV = "2.6.1+"
 
-SRC_URI = "git://github.com/csete/gqrx.git \
+SRC_URI = "git://github.com/csete/gqrx.git;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/bladerf/libbladerf_1.7.2.bb
+++ b/recipes-support/bladerf/libbladerf_1.7.2.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS = "libusb1 libtecla"
 
-SRC_URI = "git://github.com/Nuand/bladeRF.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/Nuand/bladeRF.git;protocol=https;branch=master"
 SRCREV = "ab12ebd3fb843a6df53521fbc2d47c32b835f5dd"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-air-modes/gr-air-modes_git.bb
+++ b/recipes-support/gr-air-modes/gr-air-modes_git.bb
@@ -14,7 +14,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/bistromath/gr-air-modes \
+SRC_URI = "git://github.com/bistromath/gr-air-modes;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-ais/gr-ais_git.bb
+++ b/recipes-support/gr-ais/gr-ais_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/bistromath/gr-ais;branch=master \
+SRC_URI = "git://github.com/bistromath/gr-ais;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-baz/gr-baz_git.bb
+++ b/recipes-support/gr-baz/gr-baz_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.7+git${SRCPV}"
 
-SRC_URI = "git://github.com/balint256/gr-baz;branch=master \
+SRC_URI = "git://github.com/balint256/gr-baz;branch=master;protocol=https \
            file://cross-64.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-burst/gr-burst_git.bb
+++ b/recipes-support/gr-burst/gr-burst_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.5+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-burst;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-burst;branch=master;protocol=https \
            file://cross-64.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-ettus/gr-ettus_git.bb
+++ b/recipes-support/gr-ettus/gr-ettus_git.bb
@@ -20,7 +20,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* \
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/EttusResearch/gr-ettus.git;branch=master \
+SRC_URI = "git://github.com/EttusResearch/gr-ettus.git;branch=master;protocol=https \
            file://0001-GrPlatform.cmake-Do-not-use-build-machine-files-duri.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-eventstream/gr-eventstream_git.bb
+++ b/recipes-support/gr-eventstream/gr-eventstream_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.5+git${SRCPV}"
 
-SRC_URI = "git://github.com/osh/gr-eventstream;branch=master \
+SRC_URI = "git://github.com/osh/gr-eventstream;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-framers/gr-framers_git.bb
+++ b/recipes-support/gr-framers/gr-framers_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-framers;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-framers;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-mac/gr-mac_git.bb
+++ b/recipes-support/gr-mac/gr-mac_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/jmalsbury/gr-mac;branch=master \
+SRC_URI = "git://github.com/jmalsbury/gr-mac;branch=master;protocol=https \
            file://cross-64.patch \
            file://0001-Use-CMAKE_INSTALL_LIBDIR-to-set-LIB_SUFFIX.patch \
           "

--- a/recipes-support/gr-mapper/gr-mapper_git.bb
+++ b/recipes-support/gr-mapper/gr-mapper_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-mapper;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-mapper;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-message-tools/gr-message-tools_git.bb
+++ b/recipes-support/gr-message-tools/gr-message-tools_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-message_tools;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-message_tools;branch=master;protocol=https \
            file://0001-Boost-1.67-compatibility.patch \
           "
 

--- a/recipes-support/libhackrf/libhackrf_git.bb
+++ b/recipes-support/libhackrf/libhackrf_git.bb
@@ -10,7 +10,7 @@ PV = "0.0.1"
 
 inherit cmake pkgconfig
 
-SRC_URI = "git://github.com/mossmann/hackrf.git;branch=master \
+SRC_URI = "git://github.com/mossmann/hackrf.git;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git/host"
 

--- a/recipes-support/uhd/uhd_git.bb
+++ b/recipes-support/uhd/uhd_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8255adf1069294c928e0e18b01a16282"
 
 PV = "3.10.0"
 
-SRC_URI = "git://github.com/EttusResearch/uhd.git;branch=rfnoc-devel \
+SRC_URI = "git://github.com/EttusResearch/uhd.git;branch=rfnoc-devel;protocol=https \
           "
 
 SRCREV = "8773fb2c306db98342add0a29f8863301a5c6151"

--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -16,7 +16,7 @@ export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
 PV = "1.5.0"
-SRC_URI = "git://github.com/gnuradio/volk.git;branch=master \
+SRC_URI = "git://github.com/gnuradio/volk.git;branch=master;protocol=https \
            file://0001-Check-for-lib64-verus-lib-and-set-LIB_SUFFIX-accordi.patch \
           "
 SRC_URI_append_ettus-e300 = "file://volk_config"


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 