### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-applications/gqrx/gqrx_git.bb
+++ b/recipes-applications/gqrx/gqrx_git.bb
@@ -9,7 +9,7 @@ inherit cmake_qt5
 
 PV = "2.11.5+"
 
-SRC_URI = "git://github.com/csete/gqrx.git \
+SRC_URI = "git://github.com/csete/gqrx.git;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-air-modes/gr-air-modes_git.bb
+++ b/recipes-support/gr-air-modes/gr-air-modes_git.bb
@@ -14,7 +14,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/bistromath/gr-air-modes \
+SRC_URI = "git://github.com/bistromath/gr-air-modes;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-ais/gr-ais_git.bb
+++ b/recipes-support/gr-ais/gr-ais_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/bistromath/gr-ais;branch=master \
+SRC_URI = "git://github.com/bistromath/gr-ais;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-baz/gr-baz_git.bb
+++ b/recipes-support/gr-baz/gr-baz_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.7+git${SRCPV}"
 
-SRC_URI = "git://github.com/balint256/gr-baz;branch=master \
+SRC_URI = "git://github.com/balint256/gr-baz;branch=master;protocol=https \
            file://cross-64.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-burst/gr-burst_git.bb
+++ b/recipes-support/gr-burst/gr-burst_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.5+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-burst;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-burst;branch=master;protocol=https \
            file://cross-64.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-ettus/gr-ettus_git.bb
+++ b/recipes-support/gr-ettus/gr-ettus_git.bb
@@ -20,7 +20,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* \
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/EttusResearch/gr-ettus.git;branch=master \
+SRC_URI = "git://github.com/EttusResearch/gr-ettus.git;branch=master;protocol=https \
            file://0001-GrPlatform.cmake-Do-not-use-build-machine-files-duri.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-support/gr-eventstream/gr-eventstream_git.bb
+++ b/recipes-support/gr-eventstream/gr-eventstream_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.5+git${SRCPV}"
 
-SRC_URI = "git://github.com/osh/gr-eventstream;branch=master \
+SRC_URI = "git://github.com/osh/gr-eventstream;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-framers/gr-framers_git.bb
+++ b/recipes-support/gr-framers/gr-framers_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-framers;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-framers;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-mac/gr-mac_git.bb
+++ b/recipes-support/gr-mac/gr-mac_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/jmalsbury/gr-mac;branch=master \
+SRC_URI = "git://github.com/jmalsbury/gr-mac;branch=master;protocol=https \
            file://cross-64.patch \
            file://0001-Use-CMAKE_INSTALL_LIBDIR-to-set-LIB_SUFFIX.patch \
           "

--- a/recipes-support/gr-mapper/gr-mapper_git.bb
+++ b/recipes-support/gr-mapper/gr-mapper_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-mapper;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-mapper;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-support/gr-message-tools/gr-message-tools_git.bb
+++ b/recipes-support/gr-message-tools/gr-message-tools_git.bb
@@ -15,7 +15,7 @@ FILES_${PN} += "${datadir}/gnuradio/grc/blocks/* ${libdir}/*.so"
 
 PV = "0.0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/gr-vt/gr-message_tools;branch=master \
+SRC_URI = "git://github.com/gr-vt/gr-message_tools;branch=master;protocol=https \
            file://0001-Boost-1.67-compatibility.patch \
           "
 

--- a/recipes-support/libhackrf/libhackrf_git.bb
+++ b/recipes-support/libhackrf/libhackrf_git.bb
@@ -10,7 +10,7 @@ PV = "0.0.2"
 
 inherit cmake pkgconfig
 
-SRC_URI = "git://github.com/mossmann/hackrf.git;branch=master \
+SRC_URI = "git://github.com/mossmann/hackrf.git;branch=master;protocol=https \
           "
 S = "${WORKDIR}/git/host"
 

--- a/recipes-support/uhd/uhd_3.15.LTS.bb
+++ b/recipes-support/uhd/uhd_3.15.LTS.bb
@@ -2,7 +2,7 @@ require recipes-support/uhd/uhd.inc
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8255adf1069294c928e0e18b01a16282"
 
-SRC_URI = "git://github.com/EttusResearch/uhd.git;branch=UHD-3.15.LTS \
+SRC_URI = "git://github.com/EttusResearch/uhd.git;branch=UHD-3.15.LTS;protocol=https \
            file://0001-Convert-the-asm-s16-le-converters-to-NEON-intrinsics.patch;striplevel=2 \
            file://0002-Be-more-verbose-when-checking-for-python-import.patch \
           "

--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -16,7 +16,7 @@ export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
 PV = "2.5.0"
-SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main \
+SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main;protocol=https \
            file://0001-Modify-ctest-so-we-can-package-the-testfiles-and-ins.patch \
            file://run-ptest \
           "


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos