### PR TITLE
meta-sdr: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.8.0-rc2"
+PV = "v3.10.8.0"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="54fc7d4305463de373e0798ec78e332800b8a2c2"
+SRCREV ="bd928539d9eaa73736f8381cd2e60953a0eb8cb8"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"


### PR DESCRIPTION
This is the 2023Q4.3 currency merge with upstream kirkstone branch
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2484332](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2484332)

Testing
* [x] bitbake packagefeed-ni-core
* [x] bitbake packagegroup-ni-desirable

@ni/rtos 