### PR TITLE
meta-sdr: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.9.0-rc2"
+PV = "v3.10.9.1"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV = "f717be4f566c4af8343357685bf9703acc788964"
+SRCREV = "e0711ad64f293161f9d1ce52b4817e070b604bc0"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.8.0"
+PV = "v3.10.9.0-rc1"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="bd928539d9eaa73736f8381cd2e60953a0eb8cb8"
+SRCREV = "95ee4f4e92751dd330aa3576be3e224ebf1292e9"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.9.0-rc1"
+PV = "v3.10.9.0-rc2"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV = "95ee4f4e92751dd330aa3576be3e224ebf1292e9"
+SRCREV = "f717be4f566c4af8343357685bf9703acc788964"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"

--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "The Vector Optimized Library of Kernels"
 HOMEPAGE = "http://libvolk.org"
 LICENSE = "LGPL-3.0-only"
-LIC_FILES_CHKSUM = "file://COPYING;md5=4df01d1e6b630c93c723497d44195eec"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3000208d539ec061b899bce1d9ce9404"
 
 DEPENDS = "boost python3-mako-native python3-six-native"
 
@@ -15,7 +15,7 @@ export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
-PV = "2.5.2"
+PV = "3.1.0"
 #PV = "2.5.1+git${SRCPV}"
 SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main;protocol=https \
            file://0001-Modify-ctest-so-we-can-package-the-testfiles-and-ins.patch \
@@ -25,7 +25,7 @@ SRC_URI:append_ettus-e300 = "file://volk_config"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "07c1952cd642897af70b6f8bbfeee3a14f54f525"
+SRCREV = "d1b1673eb61f936cecee769255203be790b1ad27"
 
 PACKAGES += "${PN}-modtool"
 


### PR DESCRIPTION
This is the 2024Q1.1 currency merge with upstream kirkstone branch
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2581791](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2581791)

Testing

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable

@ni/rtos 