### PR TITLE
[next] Merge upstream master ref, for currency

### DIFF
--- a/contrib/scripts/run-qemu-ptest.sh
+++ b/contrib/scripts/run-qemu-ptest.sh
@@ -27,7 +27,7 @@ if [ ${PIPESTATUS[0]} != "0" ]; then
 fi
 
 sed -i 's/\s*[0-9]*\.[0-9][0-9].sec//' ptest.log
-sed -i '/^BEGIN: \/usr\/lib\/fftw\/ptest/,/^fftw  test result:/{//!d}' ptest.log
+sed -E -i '/^BEGIN: \/usr\/lib\/fftw\/ptest/,/^PASS|^FAIL/{//!d}' ptest.log
 
 
 if [ -d ../.git ]; then

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -217,7 +217,7 @@ PV = "3.10.10.0+git${SRCPV}"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="4d3eb9f321bf28d7d6310e304a6a0323cdfa66aa"
+SRCREV ="506e68df1629a813bed2883b0668f6252b07e19a"
 
 # Make it easy to test against branches
 GIT_BRANCH = "main"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -217,7 +217,7 @@ PV = "3.10.10.0+git${SRCPV}"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="506e68df1629a813bed2883b0668f6252b07e19a"
+SRCREV ="4242290cde32a40332f294b603f93d109c3bd423"
 
 # Make it easy to test against branches
 GIT_BRANCH = "main"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -212,12 +212,12 @@ python populate_packages:prepend() {
         d.appendVar('RDEPENDS:'+pn+'-dev', ' '+' '.join(pkgs))
 }
 
-PV = "3.10.8.0+git${SRCPV}"
+PV = "3.10.10.0+git${SRCPV}"
 #PV = "3.10.0.0"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="9fca5db4e090ab79f20983be47c2b21f01d31c22"
+SRCREV ="4d3eb9f321bf28d7d6310e304a6a0323cdfa66aa"
 
 # Make it easy to test against branches
 GIT_BRANCH = "main"

--- a/recipes-images/images/native-sdk.inc
+++ b/recipes-images/images/native-sdk.inc
@@ -4,7 +4,7 @@ SDK_EXTRA_TOOLS = "  \
     nativesdk-python3-netserver nativesdk-python3-pprint \
     nativesdk-python3-pickle nativesdk-python3-shell \
     nativesdk-python3-modules \
-    nativesdk-orc nativesdk-swig nativesdk-python3-distutils \
+    nativesdk-orc nativesdk-swig \
     nativesdk-python3-xml nativesdk-python3-compile \
     nativesdk-cmake nativesdk-python3-mako nativesdk-python3-six \
     "

--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -15,7 +15,7 @@ export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
-PV = "3.0.0"
+PV = "3.1.0"
 #PV = "2.5.1+git${SRCPV}"
 SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main;protocol=https \
            file://0001-Fix-sse2neon.h-build-on-gcc-13.patch \
@@ -27,7 +27,7 @@ SRC_URI:append_ettus-e300 = "file://volk_config"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "5d7822bb3fada6f7195a6ccf9c782c92483d30ec"
+SRCREV = "d1b1673eb61f936cecee769255203be790b1ad27"
 
 PACKAGES += "${PN}-modtool"
 


### PR DESCRIPTION
This patchset merges this repo's upstream master ref into our nilrt/master/next mainline.

[AB#2565252](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2565252)

# Testing
* [x] Built the core package feed.
* [x] Built the recovery media ISO and provisioned a VM.
* [x] Booted the VM through getty.