### PR TITLE
meta-sdr: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -15,7 +15,7 @@ export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
-PV = "3.1.0"
+PV = "3.1.1"
 #PV = "2.5.1+git${SRCPV}"
 SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main;protocol=https \
            file://0001-Modify-ctest-so-we-can-package-the-testfiles-and-ins.patch \
@@ -25,7 +25,7 @@ SRC_URI:append_ettus-e300 = "file://volk_config"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "d1b1673eb61f936cecee769255203be790b1ad27"
+SRCREV = "d605d9af29ce55269911fa9c447dc89c3df8bac9"
 
 PACKAGES += "${PN}-modtool"
 


### PR DESCRIPTION
This is the 2024Q1.3 currency merge with upstream kirkstone branch.
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2581841](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2581841)

### Testing

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] unpacked resulting `nilrt-base-system-image-x64.tar` on a freshly formatted cRIO-9043 and verified the target boots into runmode w/o problems.

### Notes

- maintainers please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).