### PR TITLE
meta-sdr: Currency merge with upstream master branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,6 +22,6 @@ BBFILE_PATTERN_sdr-layer := "^${LAYERDIR}/"
 # other layers.
 
 BBFILE_PRIORITY_sdr-layer = "5"
-LAYERSERIES_COMPAT_sdr-layer = "kirkstone langdale mickledore nanbield"
+LAYERSERIES_COMPAT_sdr-layer = "kirkstone langdale mickledore nanbield scarthgap"
 LAYERDEPENDS_sdr-layer = "core meta-python openembedded-layer networking-layer \
                           filesystems-layer meta-python qt5-layer"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -217,7 +217,7 @@ PV = "3.10.10.0+git${SRCPV}"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="4242290cde32a40332f294b603f93d109c3bd423"
+SRCREV ="7d61746e27778c56eb8a805ad940c89ff265e313"
 
 # Make it easy to test against branches
 GIT_BRANCH = "main"

--- a/recipes-support/volk/volk_git.bb
+++ b/recipes-support/volk/volk_git.bb
@@ -15,10 +15,9 @@ export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
 export STAGING_LIBDIR
 
-PV = "3.1.0"
-#PV = "2.5.1+git${SRCPV}"
+#PV = "3.1.0"
+PV = "3.1.1+git${SRCPV}"
 SRC_URI = "gitsm://github.com/gnuradio/volk.git;branch=main;protocol=https \
-           file://0001-Fix-sse2neon.h-build-on-gcc-13.patch \
            file://0001-Modify-ctest-so-we-can-package-the-testfiles-and-ins.patch \
            file://0001-Do-not-compile-compiler-flags-into-volk.-This-leaks-.patch \
            file://run-ptest \
@@ -27,7 +26,7 @@ SRC_URI:append_ettus-e300 = "file://volk_config"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "d1b1673eb61f936cecee769255203be790b1ad27"
+SRCREV = "aac4c7f8cabf48135dfc22f5290c6ebca3cc9966"
 
 PACKAGES += "${PN}-modtool"
 


### PR DESCRIPTION
This is the periodic currency merge with upstream `master` branch as no `scarthgap` branch exists yet.

Did the merge using `upstream_merge.sh` script. No conflicts.

~~Also added `scarthgap` compatibility which I am going to send upstream~~ (edit: upstream addressed this couple of hours back).

WI: [AB#2468923](https://dev.azure.com/ni/DevCentral/_workitems/edit/2468923)

### Testing
- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a VM and verified it boots

### Note to maintainers
Please complete this merge manually to avoid upstream hashes being changed by GH.