### PR TITLE
Merge latest upstream to kirkstone

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.11.0-rc1"
+PV = "v3.10.11.0"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV = "45b995a67c5f245b828c7400a43634764557cf11"
+SRCREV = "1d29734d8a88f5ecb822e08ba73c3dad699258c8"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"

--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -214,11 +214,11 @@ python populate_packages:prepend() {
 }
 
 #PV = "3.10.4.0+git${SRCPV}"
-PV = "v3.10.10.0"
+PV = "v3.10.11.0-rc1"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV = "0425a9c9b5b4934fdab89812bce315e2f47d9956"
+SRCREV = "45b995a67c5f245b828c7400a43634764557cf11"
 
 # Make it easy to test against branches
 GIT_BRANCH = "maint-3.10"
@@ -226,7 +226,6 @@ GITHUB_USER = "gnuradio"
 
 SRC_URI = "git://github.com/${GITHUB_USER}/gnuradio.git;branch=${GIT_BRANCH};protocol=https \
            file://0001-Don-t-use-the-value-of-PYTHON_EXECTUABLE-probed-at-b.patch \
-           file://0001-ctrlport-probes-only-pybind-if-ctrlport-enabled.patch \
            file://run-ptest \
           "
 


### PR DESCRIPTION
[#AB2755009](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755009)

With this PR, the latest changes of meta-openembedded will be merged to nilrt/master/kirkstone. There were no merge conflicts.

**Testing**

- [x]  bitbake packagefeed-ni-core
- [X] bitbake packagegroup-ni-desirable
- [X] bitbake package-index && bitbake nilrt-base-system-image
- [X] unpacked resulting nilrt-base-system-image-x64.tar on a VM and verified the target boots into runmode w/o problems.

Note: @ni/rtos, please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).

Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>