### PR TITLE
Merge latest upstream

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -215,12 +215,12 @@ python populate_packages:prepend() {
         d.appendVar('RDEPENDS:'+pn+'-dev', ' '+' '.join(pkgs))
 }
 
-PV = "3.10.10.0+git${SRCPV}"
+PV = "3.10.12.0+git${SRCPV}"
 #PV = "3.10.0.0"
 
 FILESPATHPKG:prepend = "gnuradio-git:"
 
-SRCREV ="44aff13ce59255397ab43fa4d088dd6d3021ec89"
+SRCREV ="25af1c73628e35e12976f81b502cdcdfd51fe7c3"
 
 # Make it easy to test against branches
 GIT_BRANCH = "main"

--- a/recipes-support/gr-foo/gr-foo_git.bb
+++ b/recipes-support/gr-foo/gr-foo_git.bb
@@ -13,5 +13,5 @@ SRC_URI = "git://github.com/bastibl/gr-foo;branch=maint-3.10;protocol=https \
           "
 S = "${WORKDIR}/git"
 
-SRCREV = "0a34f68565863218c3c010e69f6bd6a9bdfd7142"
+SRCREV = "4c2a471b0453b9dca669b2d9dfcbfba6278741d7"
 


### PR DESCRIPTION
Merge latest from upstream. No conflicts.

[AB#2951016](https://dev.azure.com/ni/DevCentral/_workitems/edit/2951016)

# Testing:

- [X] Ran "bitbake packagefeed-ni-core"
- [X] Ran "bitbake packagegroup-ni-desirable"
- [X] Ran "bitbake package-index && bitbake nilrt-base-system-image"
- [X] Reimaged a cRIO (9033, 9037, 9053) with the new base image and successfully booted it